### PR TITLE
Accept both bytes and bytearray for writeCODE

### DIFF
--- a/Python/cclib/ccproxy.py
+++ b/Python/cclib/ccproxy.py
@@ -285,8 +285,7 @@ class CCLibProxy:
 			raise IOError("Unable to prepare for brust-write! (Unknown response 0x%02x)" % ans)
 
 		# Start sending data
-		for b in data:
-			self.ser.write(chr(b & 0xFF))
+		self.ser.write(data)
 		self.ser.flush()
 
 		# Handle response & update debug status

--- a/Python/cclib/chip/cc254x.py
+++ b/Python/cclib/chip/cc254x.py
@@ -524,7 +524,6 @@ class CC254X(ChipDriver):
 		self.clearDMAIRQ(1)
 		self.disarmDMAChannel(0)
 		self.disarmDMAChannel(1)
-		flashRetries = 0
 
 		# Split in 2048-byte chunks
 		iOfs = 0
@@ -603,17 +602,8 @@ class CC254X(ChipDriver):
 			# Check if we should verify
 			if verify:
 				verifyBytes = self.readCODE(fAddr, iLen)
-				for i in range(0, iLen):
-					if verifyBytes[i] != data[iOfs+i]:
-						if flashRetries < 3:
-							print "\n[Flash Error at @0x%04x, will retry]" % (fAddr+i)
-							flashRetries += 1
-							continue
-						else:
-							raise IOError("Flash verification error on offset 0x%04x" % (fAddr+i))
-			flashRetries = 0
-
-			# Forward to next page
+				if verifyBytes != data[iOfs:iOfs+iLen]:
+					raise IOError("Flash verification error on offset 0x%04x" % fAddr)
 			iOfs += iLen
 
 		if showProgress:


### PR DESCRIPTION
Make writeCODE work whether data is a bytes, str, or bytearray object. This
means we have to change any loops through data, because elements of bytes are
bytes and elements of bytearray are ints. For the write, simply pass the whole
thing to pyserial.write instead of looping through it. For verifying, check the
whole data instead of looping through it. This breaks the functionality that
the verify function tells the exact offset of the data error. The retry code is
also gone, but this already didn't really retry anything.

The motivation for this change was that CCHEXFile._loadbin returns a str, and
CCHEXFile._loadhex returns a bytearray. This change makes cc_write_flash.py
work with .bin files.