### PR TITLE
Accept DOS-style line endings in HEX files

### DIFF
--- a/Python/cclib/cchex.py
+++ b/Python/cclib/cchex.py
@@ -314,7 +314,7 @@ class CCHEXFile:
 				i += 1
 
 				# Trim ending newline
-				line = line[0:-1]
+				line = line.rstrip()
 
 				# Validate format
 				if not line[0:1] == ":":

--- a/Python/tests/test_cchex.py
+++ b/Python/tests/test_cchex.py
@@ -51,3 +51,10 @@ class TestCCHEXFile(TestCase):
     assert cchex.memBlocks[0].bytes == b"\x7F" * 16
     assert cchex.memBlocks[1].addr == 0x0500
     assert cchex.memBlocks[1].bytes == b"\x3D" * 16
+
+  def test_load_works_with_dos_style_line_endings(self):
+    hexfile = temp_hexfile(":0B0010006164647265737320676170A7\r\n")
+    cchex = CCHEXFile()
+    cchex.load(hexfile)
+
+    assert len(cchex.memBlocks) == 1


### PR DESCRIPTION
Some hex files have lines ending with \r\n instead of just \n.