### PR TITLE
Write anywhere

### DIFF
--- a/Python/cclib/chip/cc254x.py
+++ b/Python/cclib/chip/cc254x.py
@@ -563,10 +563,6 @@ class CC254X(ChipDriver):
 			cLow = fWordOffset & 0xFF
 			self.writeXDATA( 0x6271, [cLow, cHigh] )
 
-			# Debug
-			#print "[@%04x: p=%i, ofs=%04x, %02x:%02x]" % (fAddr, fPage, fWordOffset, cHigh, cLow),
-			#sys.stdout.flush()
-
 			# Check if we should erase page first
 			if erase:
 				# Select the page to erase using FADDRH[7:1]

--- a/Python/cclib/chip/cc254x.py
+++ b/Python/cclib/chip/cc254x.py
@@ -512,6 +512,11 @@ class CC254X(ChipDriver):
 		WARNING: This requires DMA operations to be unpaused ( use: self.pauseDMA(False) )
 		"""
 
+		# Pad data so that the start and end address are on 4-byte boundaries.
+		data = b"\xff" * (offset % 4) + data
+		data = data + b"\xff" * (-len(data) % 4)
+		offset -= offset % 4
+
 		# Prepare DMA-0 for DEBUG -> RAM (using DBG_BW trigger)
 		self.configDMAChannel( 0, 0x6260, 0x0000, 0x1F, tlen=self.bulkBlockSize, srcInc=0, dstInc=1, priority=1, interrupt=True )
 		# Prepare DMA-1 for RAM -> FLASH (using the FLASH trigger)

--- a/Python/cclib/chip/cc254x.py
+++ b/Python/cclib/chip/cc254x.py
@@ -556,13 +556,6 @@ class CC254X(ChipDriver):
 			fAddr = offset + iOfs
 			fPage = int( fAddr / self.flashPageSize )
 
-			# Calculate FLASH address High/Low bytes
-			# for writing (addressable as 32-bit words)
-			fWordOffset = int(fAddr / 4)
-			cHigh = (fWordOffset >> 8) & 0xFF
-			cLow = fWordOffset & 0xFF
-			self.writeXDATA( 0x6271, [cLow, cHigh] )
-
 			# Check if we should erase page first
 			if erase:
 				# Select the page to erase using FADDRH[7:1]
@@ -578,6 +571,13 @@ class CC254X(ChipDriver):
 				# Wait until flash is not busy any more
 				while self.isFlashBusy():
 					time.sleep(0.010)
+
+			# Calculate FLASH address High/Low bytes
+			# for writing (addressable as 32-bit words)
+			fWordOffset = int(fAddr / 4)
+			cHigh = (fWordOffset >> 8) & 0xFF
+			cLow = fWordOffset & 0xFF
+			self.writeXDATA( 0x6271, [cLow, cHigh] )
 
 			# Upload to FLASH through DMA-1
 			self.armDMAChannel(1)


### PR DESCRIPTION
The flash is addressable as 32-bit words, so we can only write on 32-bit boundaries. If the offset parameter to writeCODE is not divisible by 4 (bytes), we will write to the wrong location. Put 0xff on the front of data so that data is still written to the correct location.

Also, make sure the size of the data is also divisable by 4, as the documentation states: "note that the block size, LEN in configuration data, must be divisible by 4; otherwise, the last word is not written to the flash".

This is not really an ideal solution because we will now also check the 0xff padding when verifying the write. This should not happen.